### PR TITLE
Removed suboptimal clone usage

### DIFF
--- a/src/MultiNetworker.java
+++ b/src/MultiNetworker.java
@@ -49,10 +49,12 @@ public class MultiNetworker implements Networker{
 		
 
         try {
-            tempList = (ArrayList<Long>) readIntegers(request.getFileName()).clone();			//maybe revisit if clone is needed
+            tempList = new ArrayList<Long>(readIntegers(request.getFileName()));	
+		
         } catch (Exception e) {
             request.newFileName(defaultFileName); // OR use 'test' if correct
-            tempList = (ArrayList<Long>) readIntegers(request.getFileName()).clone();
+            tempList = new ArrayList<Long>(readIntegers(request.getFileName()));	
+
 		
         }
 		
@@ -97,10 +99,11 @@ public class MultiNetworker implements Networker{
 			
 
 	        try {
-	            tempList = (ArrayList<Long>) readIntegers(request.getFileName()).clone();			//maybe revisit if clone is needed
+	        	tempList = new ArrayList<Long>(readIntegers(request.getFileName()));
+	            
 	        } catch (Exception e) {
 	            request.newFileName(defaultFileName); // OR use 'test' if correct
-	            tempList = (ArrayList<Long>) readIntegers(request.getFileName()).clone();
+	            tempList = new ArrayList<Long>(readIntegers(request.getFileName()));	
 			
 	        }
 			
@@ -223,4 +226,5 @@ public class MultiNetworker implements Networker{
         }
     }
     
+  
 }

--- a/src/RealNetworker.java
+++ b/src/RealNetworker.java
@@ -40,10 +40,11 @@ public class RealNetworker implements Networker{
 		ArrayList<Long> tempList = new ArrayList<Long>();
 
         try {
-            tempList = (ArrayList<Long>) readIntegers(request.getFileName()).clone();
+            tempList = new ArrayList<Long>(readIntegers(request.getFileName()));	
         } catch (Exception e) {
             request.newFileName(defaultFileName); // OR use 'test' if correct
-            tempList = (ArrayList<Long>) readIntegers(request.getFileName()).clone();
+            tempList = new ArrayList<Long>(readIntegers(request.getFileName()));	
+
 		
         }
 		


### PR DESCRIPTION
We were previously using clone to move arraylists between networker and datastorage, by using copy constructor, we avoid using a type cast as well as any other negative side effects that may come from using the antiquated .clone() method.